### PR TITLE
feat: Suppress noisy telegram polling tracebacks with a lambda filter

### DIFF
--- a/sakurachat.py
+++ b/sakurachat.py
@@ -843,6 +843,14 @@ class ColoredFormatter(logging.Formatter):
 def setup_logging():
     # Sets up a colored logger for the bot
     """Setup colored logging configuration"""
+    # Filter out noisy polling errors from the telegram library
+    logging.getLogger("telegram.ext").addFilter(
+        lambda record: not (
+            'Exception happened while polling' in record.getMessage() and
+            'terminated by other getUpdates request' in record.getMessage()
+        )
+    )
+
     logger = logging.getLogger("SAKURA 🌸")
     logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
Adds a concise lambda function as a logging filter to the `telegram.ext` logger. This filter identifies and suppresses specific, noisy traceback messages from the `python-telegram-bot` library's polling mechanism.

This approach is more elegant and avoids the need for a separate filter class, directly addressing the issue by preventing logs containing both 'Exception happened while polling' and 'terminated by other getUpdates request' from being displayed. This results in cleaner and more readable application logs.